### PR TITLE
Minitest 5 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # rack-minitest
 
-`rack-minitest` = `rack-test` + `MiniTest`. See what I did there?
+`rack-minitest` = `rack-test` + `Minitest`. See what I did there?
 
-This gem adds some convenience methods to `rack-test` and `MiniTest` that I found myself duplicating over and over for every application I wrote. It adds a few methods for dealing with JSON to `rack-test` and `MiniTest` spec-style matchers for checking response status. The specific methods are:
+This gem adds some convenience methods to `rack-test` and `Minitest` that I found myself duplicating over and over for every application I wrote. It adds a few methods for dealing with JSON to `rack-test` and `Minitest` spec-style matchers for checking response status. The specific methods are:
 
 ```
 last_json_response
@@ -26,6 +26,12 @@ last_response.must_be_internal_server_error
 
 **NB**: This is a quick and dirty gem to hack in some functionality that I was surprised to find didn't already exist. There are tests, and they pass, but they're pretty gross. All improvements are welcome.
 
+## Requirements
+
+* [json](https://github.com/flori/json)
+* [rack-test](https://github.com/brynary/rack-test)
+* [minitest](https://github.com/seattlerb/minitest) ~> 5.0
+
 ## Installation
 
 Add this line to your application's Gemfile:
@@ -38,7 +44,7 @@ And then execute:
 
 ## Usage
 
-Just add the appropriate requires _after_ you load `rack-test` and `MiniTest`.
+Just add the appropriate requires _after_ you load `rack-test` and `Minitest`.
 
 ```
 require "rack-minitest/assertions"

--- a/lib/rack-minitest/assertions.rb
+++ b/lib/rack-minitest/assertions.rb
@@ -1,4 +1,4 @@
-module MiniTest::Assertions
+module Minitest::Assertions
 
   def assert_ok(response)
     assert_response_status response, 200

--- a/lib/rack-minitest/spec.rb
+++ b/lib/rack-minitest/spec.rb
@@ -1,4 +1,4 @@
-class MiniTest::Spec
+class Minitest::Spec
 
   include Rack::Test::Methods
 

--- a/rack-minitest.gemspec
+++ b/rack-minitest.gemspec
@@ -8,8 +8,8 @@ Gem::Specification.new do |gem|
   gem.version       = Rack::Minitest::VERSION
   gem.authors       = ["Brandon Weiss"]
   gem.email         = ["brandon@anti-pattern.com"]
-  gem.description   = %q{rack-minitest = rack-test + MiniTest}
-  gem.summary       = %q{rack-minitest = rack-test + MiniTest}
+  gem.description   = %q{rack-minitest = rack-test + Minitest}
+  gem.summary       = %q{rack-minitest = rack-test + Minitest}
   gem.homepage      = ""
 
   gem.files         = `git ls-files`.split($/)
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "json"
   gem.add_dependency "rack-test"
-  gem.add_dependency "minitest"
+  gem.add_dependency "minitest", "~> 5.0"
 
   gem.add_development_dependency "rake"
 end

--- a/test/assertions_test.rb
+++ b/test/assertions_test.rb
@@ -4,7 +4,7 @@ def stub_app(status_code)
   lambda { |env| [status_code, {}, [""]] }
 end
 
-describe MiniTest::Spec do
+describe Minitest::Spec do
 
   it "should have a spec-style matcher for an ok response" do
     def app; stub_app(200); end

--- a/test/spec_test.rb
+++ b/test/spec_test.rb
@@ -1,6 +1,6 @@
 require File.expand_path("../test_helper", __FILE__)
 
-describe MiniTest::Spec do
+describe Minitest::Spec do
 
   def app
     json = { "foo" => "bar" }.to_json
@@ -8,7 +8,7 @@ describe MiniTest::Spec do
   end
 
   it "should include Rack::Test::Methods" do
-    assert MiniTest::Spec.include? Rack::Test::Methods
+    assert Minitest::Spec.include? Rack::Test::Methods
   end
 
   it "should parse JSON responses" do


### PR DESCRIPTION
Hello Brandon,

In Minitest 5.x `MiniTest` was changed to `Minitest`. While the old style constant is still defined, this pull request makes the support explicit. I also updated the README and gemspec to reflect these changes.

I have a few more PRs to submit which will build off of these changes.

Thanks!
