### PR TITLE
Add support to pass custom headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ This gem adds some convenience methods to `rack-test` and `Minitest` that I foun
 # json
 last_json_response
 
-get_json    path, params
-post_json   path, params
-put_json    path, params
-delete_json path, params
+get_json    path, params, headers
+post_json   path, params, headers
+put_json    path, params, headers
+delete_json path, params, headers
 
 # assertions
 assert_ok

--- a/lib/rack-minitest/json.rb
+++ b/lib/rack-minitest/json.rb
@@ -7,26 +7,26 @@ module Rack
         ::JSON.parse(last_response.body)
       end
 
-      def get_json(path, params = {})
-        json_request :get, path, params
+      def get_json(path, params = {}, headers = {})
+        json_request :get, path, params, headers
       end
 
-      def post_json(path, params = {})
-        json_request :post, path, params
+      def post_json(path, params = {}, headers = {})
+        json_request :post, path, params, headers
       end
 
-      def put_json(path, params = {})
-        json_request :put, path, params
+      def put_json(path, params = {}, headers = {})
+        json_request :put, path, params, headers
       end
 
-      def delete_json(path, params = {})
-        json_request :delete, path, params
+      def delete_json(path, params = {}, headers = {})
+        json_request :delete, path, params, headers
       end
 
       private
 
-      def json_request(verb, path, params = {})
-        send verb, path, params.to_json, "CONTENT_TYPE" => "application/json"
+      def json_request(verb, path, params = {}, headers = {})
+        send verb, path, params.to_json, headers.merge({ "CONTENT_TYPE" => "application/json" })
       end
     end
   end

--- a/test/json_test.rb
+++ b/test/json_test.rb
@@ -38,4 +38,23 @@ describe Rack::Minitest::JSON do
     assert_equal "application/json", last_request.env["CONTENT_TYPE"]
   end
 
+  it "should set custom headers on get" do
+    get_json "/", {}, { "HTTP_AUTHORIZATION" => "Token token=1111" }
+    assert_equal "Token token=1111", last_request.env["HTTP_AUTHORIZATION"]
+  end
+
+  it "should set custom headers on post" do
+    post_json "/", {}, { "HTTP_AUTHORIZATION" => "Token token=1111" }
+    assert_equal "Token token=1111", last_request.env["HTTP_AUTHORIZATION"]
+  end
+
+  it "should set custom headers on put" do
+    put_json "/", {}, { "HTTP_AUTHORIZATION" => "Token token=1111" }
+    assert_equal "Token token=1111", last_request.env["HTTP_AUTHORIZATION"]
+  end
+
+  it "should set custom headers on delete" do
+    delete_json "/", {}, { "HTTP_AUTHORIZATION" => "Token token=1111" }
+    assert_equal "Token token=1111", last_request.env["HTTP_AUTHORIZATION"]
+  end
 end


### PR DESCRIPTION
Adds an additional parameter - optional - for every _verb__json to receive a hash of custom header values, while merge CONTENT_TYPE.
